### PR TITLE
adding List.rand() functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,55 @@ And with a `childKey`:
     def map = xml.toMap( 'kids' )
 
     assert map == [dan:[value:'a',kids:[[subnode:[kids:[[item:[value:'a']]]]]]]]
+
+## Extended `merge` functionality for `ConfigObject`
+
+    static ConfigObject merge( Map self, Map other, Boolean sourcePrecedence )
+
+Boolean `sourcePrecedence` specifies that the source `ConfigObject` should not have it's existing key/value
+pair overwritten by a merge with another `ConfigObject`
+
+Example:
+
+        def config1 = """
+            config {
+                a = 1
+                b = 2
+                c = 3
+            }
+        """
+        def config2 = """
+            config {
+                a = 2
+                b = 2
+            }
+        """
+        def configObject1 = new ConfigSlurper().parse(config1)
+        def configObject2 = new ConfigSlurper().parse(config2)
+        def merge = configObject2.merge(configObject1)
+
+        def configObject3 = new ConfigSlurper().parse(config1)
+        def configObject4 = new ConfigSlurper().parse(config2)
+        def mergeWithSourcePrecedence = configObject4.merge(configObject3,true)
+
+        // overwrote config2's value
+        assert merge.config.a == 1
+        // preserved config2's value
+        assert mergeWithSourcePrecedence.config.a == 2
+
+        // config2 inherited value from config1
+        assert merge.config.c == 3
+        // config2 inherited from config1
+        assert mergeWithSourcePrecedence.config.c == merge.config.c
+
+## `rand` functionality for `List`
+
+    static <T> T rand( List<T> self )
+
+Randomly select an element from a list.
+
+Example:
+
+    def list = [1, 2, 3, 4, 5]
+    def randomInt = list.rand()
+    assert randomInt in list

--- a/src/main/groovy/com/bloidonia/groovy/extensions/CollectionExtensionMethods.groovy
+++ b/src/main/groovy/com/bloidonia/groovy/extensions/CollectionExtensionMethods.groovy
@@ -23,4 +23,8 @@ class CollectionExtensionMethods {
       }
     }
   }
+
+  static <T> T rand( List<T> self ) {
+      self[new Random().nextInt(self.size())]
+  }
 }

--- a/src/test/groovy/tests/CollectionTests.groovy
+++ b/src/test/groovy/tests/CollectionTests.groovy
@@ -1,0 +1,16 @@
+package tests
+
+import spock.lang.Specification
+
+/**
+ * @author dwoods
+ * @date 11/27/12
+ */
+class CollectionTests extends Specification {
+    def 'check random list element'() {
+        given:
+        def list = (0..99).collect{it}
+        expect:
+        list.rand() in list
+    }
+}


### PR DESCRIPTION
Grab a random element from a list. Unfortunately, this commit comes with an update to the documentation for this commit and the config-object commit :-/.
